### PR TITLE
Speedup length hiding comment generation

### DIFF
--- a/lib/breach_mitigation/length_hiding.rb
+++ b/lib/breach_mitigation/length_hiding.rb
@@ -39,10 +39,7 @@ module BreachMitigation
       # data itself doesn't need to be strongly random; it just needs
       # to be resistant to compression
       length = SecureRandom.random_number(1024)
-
-      # TODO make this faster
-      junk = ''
-      length.times { junk << ALPHABET.sample }
+      junk = ALPHABET.sample(length).join
 
       "\n<!-- This is a random-length HTML comment: #{junk} -->"
     end


### PR DESCRIPTION
I believe this to be a faster option, and ran a simple benchmark to test as such:

``` ruby
require 'benchmark'
ALPHABET = ('a'..'z').to_a
N = 1000000
Benchmark.bmbm do |x|
  x.report('concatenation') do
    junk = ''
    N.times { junk << ALPHABET.sample }
  end

  x.report('join') do
    junk = ALPHABET.sample(N).join
  end
end

# Rehearsal -------------------------------------------------
# concatenation   0.420000   0.000000   0.420000 (  0.418906)
# join            0.000000   0.000000   0.000000 (  0.000019)
# ---------------------------------------- total: 0.420000sec
#
#                     user     system      total        real
# concatenation   0.410000   0.000000   0.410000 (  0.418474)
# join            0.000000   0.000000   0.000000 (  0.000018)
```
