### PR TITLE
Use MAX_LENGTH constant for random length max

### DIFF
--- a/lib/breach_mitigation/length_hiding.rb
+++ b/lib/breach_mitigation/length_hiding.rb
@@ -38,7 +38,7 @@ module BreachMitigation
       # The length of the padding should be strongly random, but the
       # data itself doesn't need to be strongly random; it just needs
       # to be resistant to compression
-      length = SecureRandom.random_number(1024)
+      length = SecureRandom.random_number(MAX_LENGTH)
       junk = ALPHABET.sample(length).join
 
       "\n<!-- This is a random-length HTML comment: #{junk} -->"


### PR DESCRIPTION
`MAX_LENGTH` wasn't being used. This swaps out the hardcoded max length value of `1024` for the constant.
