### PR TITLE
Insert middleware before Rack::ETag

### DIFF
--- a/lib/breach_mitigation/railtie.rb
+++ b/lib/breach_mitigation/railtie.rb
@@ -4,7 +4,7 @@ require 'breach_mitigation/masking_secrets'
 module BreachMitigation
   class Railtie < Rails::Railtie
     initializer "breach-mitigation-rails.insert_middleware" do |app|
-      app.config.middleware.use "BreachMitigation::LengthHiding"
+      app.config.middleware.insert_before 'Rack::ETag', "BreachMitigation::LengthHiding"
     end
   end
 end


### PR DESCRIPTION
> The length-hiding middleware adds random text (in the form of an HTML comment) to every page you serve. This can break HTTP caching / ETags for public pages since they are no longer identical on each request.

This can easily be resolved by letting `BreachMitigation::LengthHiding` do it's work after `Rack::ETag`.

I didn't test his, but seems fairly obvious.
