### PR TITLE
HTML-safe the Length Hiding HTML comment

### DIFF
--- a/lib/breach_mitigation/length_hiding.rb
+++ b/lib/breach_mitigation/length_hiding.rb
@@ -41,7 +41,7 @@ module BreachMitigation
       length = SecureRandom.random_number(MAX_LENGTH)
       junk = ALPHABET.sample(length).join
 
-      "\n<!-- This is a random-length HTML comment: #{junk} -->"
+      "\n<!-- This is a random-length HTML comment: #{junk} -->".html_safe
     end
   end
 end


### PR DESCRIPTION
I noticed some weird behavior in Rails dev vs production environments where the HTML comment was being escaped in responses when using the production environment.  To mitigate this issue, I've modified the length padding to call `html_safe` on the string.
