### PR TITLE
Only append length hiding string on HTTPS requests

### DIFF
--- a/lib/breach_mitigation/length_hiding.rb
+++ b/lib/breach_mitigation/length_hiding.rb
@@ -8,7 +8,7 @@ module BreachMitigation
       status, headers, body = @app.call(env)
 
       # Only pad HTML documents
-      if headers['Content-Type'] =~ /text\/html/
+      if headers['Content-Type'] =~ /text\/html/ && env['rack.url_scheme'] == 'https'
         # Copy the existing response to a new object
         response = Rack::Response.new(body, status, headers)
 


### PR DESCRIPTION
There's no need to add that extra data on normal HTTP requests.
