### PR TITLE
allow length-hiding to be disabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ And then execute:
 
     $ bundle
 
+The length-hiding can be disabled by doing:
+
+    Rails.application.config.exclude_breach_length_hiding = true
+
 For most Rails apps, that should be enough, but read on for the gory
 details...
 

--- a/breach-mitigation-rails.gemspec
+++ b/breach-mitigation-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "active_support"
+  spec.add_dependency "activesupport"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec"

--- a/lib/breach_mitigation/length_hiding.rb
+++ b/lib/breach_mitigation/length_hiding.rb
@@ -9,8 +9,8 @@ module BreachMitigation
     def call(env)
       status, headers, body = @app.call(env)
 
-      # Only pad HTML documents
-      if headers['Content-Type'] =~ /text\/html/ && env['rack.url_scheme'] == 'https'
+      # Only pad HTML/XHTML documents
+      if headers['Content-Type'] =~ /text\/x?html/ && env['rack.url_scheme'] == 'https'
         # Copy the existing response to a new object
         response = Rack::Response.new(body, status, headers)
 

--- a/lib/breach_mitigation/railtie.rb
+++ b/lib/breach_mitigation/railtie.rb
@@ -1,13 +1,15 @@
-require 'breach_mitigation/length_hiding'
 require 'breach_mitigation/masking_secrets'
 
 module BreachMitigation
   class Railtie < Rails::Railtie
     initializer "breach-mitigation-rails.insert_middleware" do |app|
-      if Rails.version.include?("3.0.")
-        app.config.middleware.use "BreachMitigation::LengthHiding"
-      else
-        app.config.middleware.insert_before "Rack::ETag", "BreachMitigation::LengthHiding"
+      if !app.config.respond_to?(:exclude_breach_length_hiding) || !app.config.exclude_breach_length_hiding
+        require 'breach_mitigation/length_hiding'
+        if Rails.version.include?("3.0.")
+          app.config.middleware.use "BreachMitigation::LengthHiding"
+        else
+          app.config.middleware.insert_before "Rack::ETag", "BreachMitigation::LengthHiding"
+        end
       end
     end
   end

--- a/lib/breach_mitigation/version.rb
+++ b/lib/breach_mitigation/version.rb
@@ -1,3 +1,3 @@
 module BreachMitigation
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'rubygems'
 require 'bundler/setup'
+require 'securerandom'
 
 require 'breach-mitigation-rails'
 


### PR DESCRIPTION
This will:
- leave length-hiding turned on by default, but allow you to disable it if you want.  Given how the length-hiding interacts with Rack, streaming, etc., this is sometimes desirable.
- pad both html and xhtml responses.
- refer to `ActiveSupport` as `activesupport` rather than `active_support` in the gemspec.
- require `securerandom` in `spec_helper.rb`, so that tests can be run locally.
