### PR TITLE
Properly detect https on proxied connections

### DIFF
--- a/lib/breach_mitigation/length_hiding.rb
+++ b/lib/breach_mitigation/length_hiding.rb
@@ -10,7 +10,7 @@ module BreachMitigation
       status, headers, body = @app.call(env)
 
       # Only pad HTML documents
-      if headers['Content-Type'] =~ /text\/html/ && env['rack.url_scheme'] == 'https'
+      if headers['Content-Type'] =~ /text\/html/ && Rack::Request.new(env).ssl?
         # Copy the existing response to a new object
         response = Rack::Response.new(body, status, headers)
 


### PR DESCRIPTION
When a load balancer (e.g. BigIP, nginx) is used to terminate SSL, the connections to the backend appservers within the local datacenter will be over http.  They usually set a request header to indicate that the request was made over SSL and Rack knows several of the most common that are used.  This switches to using the SSL detection built into a Rack request object instead of just using the Rack request scheme.

I looked into adding a test, but your existing specs seem to only cover the function to pad the request length.  Please let me know if you'd prefer that add specs for the call function for you.
