### PR TITLE
Fix activesupport gem name

### DIFF
--- a/breach-mitigation-rails.gemspec
+++ b/breach-mitigation-rails.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "active_support"
+  spec.add_dependency "activesupport"
   spec.add_dependency "rack"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
The proper name of the Active Support gem seems to be `activesupport`. There is an `active_support` gem, but it has been yanked. This doesn't change the paths used with `require` which still include `active_support`.

We cannot upgrade to breach-mitigation-rails 0.1.0 without this change.

Note: I edited the gemspec on GitHub, so I haven't actually verified that this works, but I have confirmed the proper gem name.
