### PR TITLE
Handle non-string authenticity tokens gracefully

### DIFF
--- a/lib/breach_mitigation/masking_secrets.rb
+++ b/lib/breach_mitigation/masking_secrets.rb
@@ -23,7 +23,7 @@ module BreachMitigation
         return false if encoded_masked_token.nil? || encoded_masked_token.empty?
 
         begin
-          masked_token = Base64.strict_decode64(encoded_masked_token)
+          masked_token = Base64.strict_decode64(encoded_masked_token.to_s)
         rescue ArgumentError # encoded_masked_token is invalid Base64
           return false
         end

--- a/spec/masking_secrets_spec.rb
+++ b/spec/masking_secrets_spec.rb
@@ -45,5 +45,9 @@ describe BreachMitigation::MaskingSecrets do
     it "returns false for a token of the wrong length" do
       masking_secrets.valid_authenticity_token?(session, SecureRandom.base64(2)).should == false
     end
+
+    it "returns false for a non-string token" do
+      masking_secrets.valid_authenticity_token?(session, ["foo", "bar"]).should == false
+    end
   end
 end


### PR DESCRIPTION
Non-string authenticity tokens causes exceptions. These are generated by some automatic scanners that check if an application is vulnerable by replacing authenticity token with non-string data.  

Some automatic scanners check if an application is vulnerable by replacing authenticity token with non-string data.  As `Base64.strict_decode` only handles strings, let's stringify objects before decoding.
