### PR TITLE
Allow form_authenticity_param to be overridden as in ActionPack

### DIFF
--- a/lib/breach_mitigation/railtie.rb
+++ b/lib/breach_mitigation/railtie.rb
@@ -23,7 +23,7 @@ module ActionController
 
     def verified_request?
       !protect_against_forgery? || request.get? || request.head? ||
-        BreachMitigation::MaskingSecrets.valid_authenticity_token?(session, params[request_forgery_protection_token]) ||
+        BreachMitigation::MaskingSecrets.valid_authenticity_token?(session, form_authenticity_param) ||
         BreachMitigation::MaskingSecrets.valid_authenticity_token?(session, request.headers['X-CSRF-Token'])
     end
 


### PR DESCRIPTION
ActionPack exposes `form_authenticity_param` to allow the authenticity param lookup to be overridden (https://github.com/rails/rails/commit/e1385be025263fad6d339010d42fe553d1de64af). The monkey patch does not leverage the method so we loose this ability. This change calls the method rather than using the params lookup.
