### PR TITLE
Fix middleware deprecation message with Rails 5

### DIFF
--- a/lib/breach_mitigation/railtie.rb
+++ b/lib/breach_mitigation/railtie.rb
@@ -7,8 +7,12 @@ module BreachMitigation
         require 'breach_mitigation/length_hiding'
         if Rails.version.include?("3.0.")
           app.config.middleware.use "BreachMitigation::LengthHiding"
+        elsif Rails.version >= '5'
+          app.config.middleware.insert_before Rack::ETag,
+            BreachMitigation::LengthHiding
         else
-          app.config.middleware.insert_before "Rack::ETag", "BreachMitigation::LengthHiding"
+          app.config.middleware.insert_before "Rack::ETag"
+            "BreachMitigation::LengthHiding"
         end
       end
     end


### PR DESCRIPTION
by using the actual class references.

"DEPRECATION WARNING: Passing strings or symbols to the middleware
builder is deprecated, please change them to actual class references."

Related to rails/rails #21175 and #21172.
